### PR TITLE
Move manpage to usual Unix games category (6)

### DIFF
--- a/Makefile.gcw0
+++ b/Makefile.gcw0
@@ -76,8 +76,8 @@ install:
 	cp -R ./tools/releaser/data/gcw0/* "$(DESTDIR)$(DATADIR)"
 	find "$(DESTDIR)$(DATADIR)" -type d -exec chmod 755 {} \;
 	find "$(DESTDIR)$(DATADIR)" -type f \! -executable -exec chmod 644 {} \;
-	install -d "$(DESTDIR)$(MANDIR)man1/"
-	install -m 644 doc/wizznic.1 "$(DESTDIR)$(MANDIR)man1/"
+	install -d "$(DESTDIR)$(MANDIR)man6/"
+	install -m 644 doc/wizznic.6 "$(DESTDIR)$(MANDIR)man6/"
 	mksquashfs $(DESTDIR) $(OPKNAME)_GCW0_$(RELEASE_VERSION)_$(BUILD_NUMBER).opk -all-root -noappend -no-exports -no-xattrs
 
 clean:

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -82,8 +82,8 @@ install:
 	cp -R packs "$(DESTDIR)$(DATADIR)"
 	find "$(DESTDIR)$(DATADIR)" -type d -exec chmod 755 {} \;
 	find "$(DESTDIR)$(DATADIR)" -type f \! -executable -exec chmod 644 {} \;
-	install -d "$(DESTDIR)$(MANDIR)man1/"
-	install -m 644 doc/wizznic.1 "$(DESTDIR)$(MANDIR)man1/"
+	install -d "$(DESTDIR)$(MANDIR)man6/"
+	install -m 644 doc/wizznic.6 "$(DESTDIR)$(MANDIR)man6/"
 
 clean:
 	rm -f $(NAME) src/*.o src/platform/*.o src/list/*.o mkbundle.bin

--- a/doc/wizznic.6
+++ b/doc/wizznic.6
@@ -1,5 +1,5 @@
 .Dd October 6, 2013
-.Dt WIZZNIC 1
+.Dt WIZZNIC 6
 .Os
 .Sh NAME
 .Nm wizznic


### PR DESCRIPTION
As shown here, the typical category for games on Unix is man6, while man1 is reserved to general shell commands: https://en.wikipedia.org/wiki/Man_page#Manual_sections

I've adapted the makefiles accordingly, but you might want to check the gcw0 changes as I have no experience with this platform, and don't know if "6" is a valid man category there.