### PR TITLE
Respect CC set in the environment

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -2,7 +2,7 @@
 #To make a system-wide install add DATADIR=/dir/to/data/ and BINDIR=/dir/to/bin/ to the make command
 #To compile without OpenGL scaling support, add WITH_OPENGL=false to the make command.
 
-CC = gcc
+CC ?= gcc
 LD = $(CC)
 STRIP = strip
 MAKE = make


### PR DESCRIPTION
This is needed for e.g. packaging, where systemwide CC is passed via environment, and in fact there is no `gcc` binary at all.